### PR TITLE
Update xmlsec dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,7 @@ em = Extension("xmlsecmod",
 doclines = __doc__.split("\n")
 
 setup(name = "pyxmlsec",
-      version = "svn",
+      version = "0.4.0",
       description = doclines[0],
       long_description = "\n" . join(doclines[2:]),
       author = "Valery Febvre",

--- a/x509.c
+++ b/x509.c
@@ -30,20 +30,19 @@
 PyObject *xmlsec_X509DataGetNodeContent(PyObject *self, PyObject *args) {
   PyObject *node_obj, *keyInfoCtx_obj;
   xmlNodePtr node;
-  int deleteChildren;
   xmlSecKeyInfoCtxPtr keyInfoCtx;
   int ret;
 
   if (CheckArgs(args, "OIO:x509DataGetNodeContent")) {
     if (!PyArg_ParseTuple(args, "OiO:x509DataGetNodeContent", &node_obj,
-			  &deleteChildren, &keyInfoCtx_obj))
+			  &keyInfoCtx_obj))
       return NULL;
   }
   else return NULL;
 
   node = xmlNodePtr_get(node_obj);
   keyInfoCtx = xmlSecKeyInfoCtxPtr_get(keyInfoCtx_obj);
-  ret = xmlSecX509DataGetNodeContent(node, deleteChildren, keyInfoCtx);
+  ret = xmlSecX509DataGetNodeContent(node, keyInfoCtx);
 
   return wrap_int(ret);
 }

--- a/xmlsec.py
+++ b/xmlsec.py
@@ -3571,14 +3571,13 @@ X509DATA_SKI_NODE          = 0x00000008
 X509DATA_CRL_NODE          = 0x00000010
 # Default set of nodes to write in case of empty <dsig:X509Data/> node template.
 X509DATA_DEFAULT           = X509DATA_CERTIFICATE_NODE | X509DATA_CRL_NODE
-def x509DataGetNodeContent(node, deleteChildren, keyInfoCtx):
+def x509DataGetNodeContent(node, keyInfoCtx):
     """
     Reads the contents of <dsig:X509Data/> node and returns it as a bits mask.
     node           : the <dsig:X509Data/> node.
-    deleteChildren : the flag that indicates whether to remove node children
     after reading.
     keyInfoCtx     : the <dsig:KeyInfo/> node processing context.
     Returns        : the bit mask representing the <dsig:X509Data/> node content
     or a negative value if an error occurs.
     """
-    return xmlsecmod.x509DataGetNodeContent(node, deleteChildren, keyInfoCtx)
+    return xmlsecmod.x509DataGetNodeContent(node, keyInfoCtx)


### PR DESCRIPTION
As of this commit (2 years ago) https://github.com/lsh123/xmlsec/commit/2632a64a6dc414c9b253471fad00d4a117461eaf, xmlsec no longer uses the deleteChildren flag. 